### PR TITLE
Fix/setup find packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ requires = [
 setup(
     name="spacyface",
     description="Aligner for spacy and huggingface tokenization",
-    packages=['spacyface'],
-    version='0.2.1',
+    packages=find_packages(exclude=['tests']),
+    version='0.2.3',
     license='Apache 2.0',
     author="Ben Hoover",
     author_email="benjamin.hoover@ibm.com",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name="spacyface",
     description="Aligner for spacy and huggingface tokenization",
     packages=find_packages(exclude=['tests']),
-    version='0.2.3',
+    version='0.2.2',
     license='Apache 2.0',
     author="Ben Hoover",
     author_email="benjamin.hoover@ibm.com",


### PR DESCRIPTION
When installing version 2.1 the spacyface.utils subpackage was not getting installed.  Consequently the following import
```python
from spacyface import DistilBertAligner
```

Resulted in the following error message:
```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-5e05dd4a879c> in <module>
      2 
      3 from transformers import AutoModel
----> 4 from spacyface import DistilBertAligner
      5 import numpy as np

~/venvs/nlpenv/lib/python3.6/site-packages/spacyface/__init__.py in <module>
----> 1 from .aligner import (
      2     MakeAligner,
      3     BertAligner,
      4     GPT2Aligner,
      5     RobertaAligner,

~/venvs/nlpenv/lib/python3.6/site-packages/spacyface/aligner.py in <module>
     24 
     25 from .simple_spacy_token import SimpleSpacyToken
---> 26 from .utils.f import flatten_, assoc, delegates
     27 
     28 def doc_to_fixed_tokens(doc: SpacyDoc) -> List[str]:

ModuleNotFoundError: No module named 'spacyface.utils'
```

The causes of this are twofold:
1. `utils` had no `__init__.py`
1. `setup.py` packages referenced only the top-level spacyface package, so no subpackages were installed.

The fix adds the `__init__.py` and uses the `find_packages()` function instead of the hard-coded one.